### PR TITLE
update and pin pre-commit dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 21.9b0
+    rev: 22.1.0
     hooks:
       - id: black
 
@@ -9,18 +9,18 @@ repos:
     hooks:
       - id: flake8
         additional_dependencies:
-          - flake8-bugbear
-          - flake8-comprehensions
-          - flake8-simplify
-          - pep8-naming
+          - flake8-bugbear==22.1.11
+          - flake8-comprehensions==3.8.0
+          - flake8-simplify==0.18.0
+          - pep8-naming==0.12.1
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.9.3
+    rev: 5.10.1
     hooks:
       - id: isort
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.29.1
+    rev: v2.31.0
     hooks:
       - id: pyupgrade
         args:


### PR DESCRIPTION
pinning the flake8 "additional dependencies" ensures consistent behaviour locally and in CI