### PR TITLE
Adds support for arbitrary additional HTTP headers

### DIFF
--- a/zammad_py/api.py
+++ b/zammad_py/api.py
@@ -46,7 +46,7 @@ class ZammadAPI:
 
         if self._on_behalf_of:
             self.session.headers["X-On-Behalf-Of"] = self._on_behalf_of
-        
+
         if self._additional_headers:
             for additional_header in self._additional_headers:
                 self.session.headers[additional_header[0]] = additional_header[1]

--- a/zammad_py/api.py
+++ b/zammad_py/api.py
@@ -21,7 +21,7 @@ class ZammadAPI:
         http_token: Optional[str] = None,
         oauth2_token: Optional[str] = None,
         on_behalf_of: Optional[str] = None,
-        additional_headers: List[Tuple[str, str]] = None,
+        additional_headers: Optional[List[Tuple[str, str]]] = None,
     ) -> None:
         self.url = url
         self._username = username

--- a/zammad_py/api.py
+++ b/zammad_py/api.py
@@ -2,7 +2,7 @@
 import atexit
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
-from typing import Any, Generator, Optional
+from typing import Any, Generator, List, Optional, Tuple
 
 import requests
 from requests.exceptions import HTTPError
@@ -21,6 +21,7 @@ class ZammadAPI:
         http_token: Optional[str] = None,
         oauth2_token: Optional[str] = None,
         on_behalf_of: Optional[str] = None,
+        additional_headers: List[Tuple[str, str]] = None,
     ) -> None:
         self.url = url
         self._username = username
@@ -28,6 +29,7 @@ class ZammadAPI:
         self._http_token = http_token
         self._oauth2_token = oauth2_token
         self._on_behalf_of = on_behalf_of
+        self._additional_headers = additional_headers
         self._check_config()
 
         self.session = requests.Session()
@@ -44,6 +46,10 @@ class ZammadAPI:
 
         if self._on_behalf_of:
             self.session.headers["X-On-Behalf-Of"] = self._on_behalf_of
+        
+        if self._additional_headers:
+            for additional_header in self._additional_headers:
+                self.session.headers[additional_header[0]] = additional_header[1]
 
     def _check_config(self) -> None:
         """Check the configuration"""


### PR DESCRIPTION
In our use case we need to authenticate to a zero-trust access proxy before we can hit the API, but this solution should be generic enough to be useful in many different ways.