### PR TITLE
Merge feature

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -156,6 +156,8 @@ The :class:`~zammad_py.api.Ticket` resource also has the :meth:`~zammad_py.api.T
 Further, it has the :meth:`~zammad_py.api.Ticket.merge()` method, that allows to merge two tickets. (This is not documented in the Zammad API Documentation)
 The method requires the Ticket id of the Child (The ticket you want to merge into the parent) and the Ticket Number of the Parent Ticket. (The ticket you want to contain the articles of the child after merging.)
 
+Important: If you want to use the merge functionality, you need to use password, hot http_token for your authentication.
+
 .. code-block:: python
 
     from zammad_py import ZammadAPI

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -152,6 +152,17 @@ The :class:`~zammad_py.api.Ticket` resource also has the :meth:`~zammad_py.api.T
     ticketarticles = client.ticket.articles
     print(ticketarticles)
 
+
+Further, it has the :meth:`~zammad_py.api.Ticket.merge()` method, that allows to merge two tickets. (This is not documented in the Zammad API Documentation)
+The method requires the Ticket id of the Child (The ticket you want to merge into the parent) and the Ticket Number of the Parent Ticket. (The ticket you want to contain the articles of the child after merging.)
+
+.. code-block:: python
+
+    from zammad_py import ZammadAPI
+    client = ZammadAPI(url='<HOST>', username='<USERNAME>', password='<PASSWORD>')
+    client.ticket.merge(id=<ID>,number=<NUMBER>)
+
+
 Link Resource
 -------------
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -156,7 +156,7 @@ The :class:`~zammad_py.api.Ticket` resource also has the :meth:`~zammad_py.api.T
 Further, it has the :meth:`~zammad_py.api.Ticket.merge()` method, that allows to merge two tickets. (This is not documented in the Zammad API Documentation)
 The method requires the Ticket id of the Child (The ticket you want to merge into the parent) and the Ticket Number of the Parent Ticket. (The ticket you want to contain the articles of the child after merging.)
 
-Important: If you want to use the merge functionality, you need to use password, hot http_token for your authentication.
+Important: If you want to use the merge functionality, you need to use password, not http_token for your authentication.
 
 .. code-block:: python
 

--- a/tests/fixtures/zammad_groups.yml
+++ b/tests/fixtures/zammad_groups.yml
@@ -42,7 +42,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [Zammad API Python]
     method: GET
-    uri: http://localhost/api/v1/groups/1?expand=true
+    uri: http://localhost/api/v1/groups/1
   response:
     body:
       string: !!binary |

--- a/tests/fixtures/zammad_tickets.yml
+++ b/tests/fixtures/zammad_tickets.yml
@@ -46,7 +46,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [Zammad API Python]
     method: GET
-    uri: http://localhost/api/v1/tickets/1?expand=true
+    uri: http://localhost/api/v1/tickets/1
   response:
     body:
       string: !!binary |

--- a/tests/fixtures/zammad_users.yml
+++ b/tests/fixtures/zammad_users.yml
@@ -90,7 +90,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [Zammad API Python]
     method: GET
-    uri: http://localhost/api/v1/users/3?expand=true
+    uri: http://localhost/api/v1/users/3
   response:
     body:
       string: !!binary |

--- a/zammad_py/api.py
+++ b/zammad_py/api.py
@@ -293,7 +293,8 @@ class Ticket(Resource):
         """
 
         response = self._connection.session.put(
-            self._connection.url + "ticket_merge/%s/%s" % (id, number))
+            self._connection.url + f"ticket_merge/{id}/{number}"
+        )
         return self._raise_or_return_json(response)
 
 class Link(Resource):

--- a/zammad_py/api.py
+++ b/zammad_py/api.py
@@ -284,6 +284,17 @@ class Ticket(Resource):
         )
         return self._raise_or_return_json(response)
 
+    def merge(self, id, number):
+        """Merges two tickets, (undocumented in Zammad Docs)
+        If the objects are already merged, it will return "Object already exists!"
+
+        :param id: Ticket id of the child
+        :param number: Ticket Number of the Parent
+        """
+        response = self._connetion.session.get(
+            self._connection.url + "ticket_merge/%s/%s" % id, number
+            )
+        return self._raise_or_return_json(response)
 
 class Link(Resource):
     path_attribute = "links"

--- a/zammad_py/api.py
+++ b/zammad_py/api.py
@@ -234,7 +234,7 @@ class Resource(ABC):
 
         :param id: Resource id
         """
-        response = self._connection.session.get(self.url + "/%s?expand=true" % id)
+        response = self._connection.session.get(self.url + "/%s" % id)
         return self._raise_or_return_json(response)
 
     def create(self, params):
@@ -287,13 +287,13 @@ class Ticket(Resource):
     def merge(self, id, number):
         """Merges two tickets, (undocumented in Zammad Docs)
         If the objects are already merged, it will return "Object already exists!"
-
+        Attention: Must use password to authenticate to Zammad, otherwise this will not work!
         :param id: Ticket id of the child
         :param number: Ticket Number of the Parent
         """
-        response = self._connetion.session.get(
-            self._connection.url + "ticket_merge/%s/%s" % id, number
-            )
+
+        response = self._connection.session.put(
+            self._connection.url + "ticket_merge/%s/%s" % (id, number))
         return self._raise_or_return_json(response)
 
 class Link(Resource):

--- a/zammad_py/api.py
+++ b/zammad_py/api.py
@@ -297,6 +297,7 @@ class Ticket(Resource):
         )
         return self._raise_or_return_json(response)
 
+
 class Link(Resource):
     path_attribute = "links"
 


### PR DESCRIPTION
The `zammad_py.api.Ticket.merge()` method allows to merge two tickets. 
(This is not documented in the Zammad API Documentation)

The method requires the Ticket id of the Child (The ticket you want to merge into the parent) and the Ticket Number of the Parent Ticket. (The ticket you want to contain the articles of the child after merging.)

Important: If you want to use the merge functionality, you need to use password, not http_token for your authentication.

```
    from zammad_py import ZammadAPI
    client = ZammadAPI(url='<HOST>', username='<USERNAME>', password='<PASSWORD>')
    client.ticket.merge(id=<ID>,number=<NUMBER>)
```