### PR TITLE
Allow override of params with filters

### DIFF
--- a/zammad_py/api.py
+++ b/zammad_py/api.py
@@ -231,7 +231,10 @@ class Resource(ABC):
         :param filters: Filter arguments like page, per_page
         """
         params = filters or {}
-        params.update({"page": page, "per_page": self._per_page, "expand": "true"})
+        defaults = {"page": page, "per_page": self._per_page, "expand": "true"}
+        for key in defaults:
+            if key not in filters:
+                params.update({key:defaults[key]})
         response = self._connection.session.get(self.url, params=params)
         data = self._raise_or_return_json(response)
         return Pagination(
@@ -251,7 +254,10 @@ class Resource(ABC):
         """
         params = filters or {}
         params.update({"query": search_string})
-        params.update({"page": page, "per_page": self._per_page, "expand": "true"})
+        defaults = {"page": page, "per_page": self._per_page, "expand": "true"}
+        for key in defaults:
+            if key not in filters:
+                params.update({key:defaults[key]})
         response = self._connection.session.get(self.url + "/search", params=params)
         data = self._raise_or_return_json(response)
         return Pagination(


### PR DESCRIPTION
Although the comments in code say that setting the values  of "per_page" or "page" is possible using the "filters" parameter of the all() or search() methods, in reality those values are overwritten with "params.update()". Changed the behaviour for these functions to check whether the values to be updated in the "params" exist in filters. Update the values only if they are not present in filters.