### PR TITLE
make session injectable

### DIFF
--- a/zammad_py/api.py
+++ b/zammad_py/api.py
@@ -22,6 +22,7 @@ class ZammadAPI:
         oauth2_token: Optional[str] = None,
         on_behalf_of: Optional[str] = None,
         additional_headers: Optional[List[Tuple[str, str]]] = None,
+        session: requests.Session = None,
     ) -> None:
         self.url = url if url.endswith("/") else f"{url}/"
         self._username = username
@@ -32,7 +33,7 @@ class ZammadAPI:
         self._additional_headers = additional_headers
         self._check_config()
 
-        self.session = requests.Session()
+        self.session = session or requests.Session()
         atexit.register(self.session.close)
         self.session.headers["User-Agent"] = "Zammad API Python"
         if self._http_token:


### PR DESCRIPTION
Related to #247

Add a way to optionally inject a session instead of using the default `requests.Session`.  
This will allow to specify specific parameters of the session and even add global timeout handling for all Zammad requests.

```python

class SessionWithDefaultTimeout(requests.Session):
    DEFAULT_CONNECT_TIMEOUT = 3
    DEFAULT_READ_TIMEOUT = 30

    def __init__(self, timeout: int | tuple[int, int] = (DEFAULT_CONNECT_TIMEOUT, DEFAULT_READ_TIMEOUT)):
        """
        timeout can either be an integer that is the used for connect and read timeout
        or a tuple of two integers that are then first connect and second read timeout
        """
        self.timeout = timeout
        super().__init__()

    def request(self, method, url, **kwargs):
        if "timeout" not in kwargs:
            kwargs["timeout"] = self.timeout
        return super().request(method, url, **kwargs)

zammad = ZammadAPI(session=SessionWithDefaultTimeout())
```