### PR TITLE
Add TimeAccounting resource and related methods for ticket time accounting

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Most resources support these methods:
 | TicketState | `client.ticket_state` |
 | TagList | `client.taglist` |
 | TicketTag | `client.ticket_tag` |
+| TimeAccounting | `client.time_accounting` |
 | KnowledgeBases | `client.knowledge_bases` |
 | KnowledgeBasesAnswers | `client.knowledge_bases_answers` |
 | KnowledgeBasesCategories | `client.knowledge_bases_categories` |
@@ -82,6 +83,7 @@ Most resources support these methods:
 ### Ticket
 - `.articles(id)`: Returns all articles associated with a ticket.
 - `.tags(id)`: Returns all tags associated with a ticket.
+- `.time_accountings(id)`: Returns all time accounting entries for a ticket.
 - `.merge(id, number)`: Merges two tickets (requires password auth).
 
 ### Link
@@ -100,6 +102,10 @@ Most resources support these methods:
 ### TicketTag
 - `.add(id, tag)`: Adds a tag to a ticket.
 - `.remove(id, tag)`: Removes a tag from a ticket.
+
+### TimeAccounting
+- `.log_by_activity(year, month)`: Returns monthly time accounting grouped by activity as JSON.
+- `.log_by_activity_download(year, month)`: Returns monthly time accounting grouped by activity as a downloadable file (bytes).
 
 ### KnowledgeBases
 - `.init()`: Returns the entire knowledge base structure.

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Most resources support these methods:
 - `.remove(id, tag)`: Removes a tag from a ticket.
 
 ### TimeAccounting
+- Note: standard CRUD/search methods such as `.all()`, `.find()`, and `.search()` are intentionally unsupported for this resource and raise `UnusedResourceError`.
 - `.log_by_activity(year, month)`: Returns monthly time accounting grouped by activity as JSON.
 - `.log_by_activity_download(year, month)`: Returns monthly time accounting grouped by activity as a downloadable file (bytes).
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -126,6 +126,7 @@ Available Resources
     ticketpriority
     ticketstate
     tickettag
+    time_accounting
     object
     taglist
 
@@ -164,6 +165,16 @@ The :class:`~zammad_py.api.Ticket` resource also has the :meth:`~zammad_py.api.T
     ticket_tags = client.ticket.tags((<ID>))
     for ttag in ticket_tags['tags']:
         print(ttga)
+
+The :class:`~zammad_py.api.Ticket` resource also has the :meth:`~zammad_py.api.Ticket.time_accountings()` method to get all time accounting entries associated with a ticket.
+
+.. code-block:: python
+
+    from zammad_py import ZammadAPI
+    client = ZammadAPI(url='<HOST>', username='<USERNAME>', password='<PASSWORD>')
+    ticket_time_accountings = client.ticket.time_accountings(<ID>)
+    for record in ticket_time_accountings:
+        print(record['time_unit'])
 
 Further, it has the :meth:`~zammad_py.api.Ticket.merge()` method, that allows to merge two tickets. (This is not documented in the Zammad API Documentation)
 The method requires the Ticket id of the Child (The ticket you want to merge into the parent) and the Ticket Number of the Parent Ticket. (The ticket you want to contain the articles of the child after merging.)
@@ -259,6 +270,24 @@ The :class `~zammad_py.api.TicketTag` resource handles tags in the ticket scope 
     client.ticket_tag.remove(<ID>, 'Zammad')
     ticket_tags = client.ticket.tags((<ID>))
     print(ticket_tags['tags'])  # ['TestTag', 'FancyNewTag']
+
+TimeAccounting Resource
+-----------------------
+
+The :class:`~zammad_py.api.TimeAccounting` resource provides month-based activity reports.
+
+:meth:`zammad_py.api.TimeAccounting.log_by_activity`
+   | Returns monthly time accounting grouped by activity as JSON.
+
+:meth:`zammad_py.api.TimeAccounting.log_by_activity_download`
+   | Returns monthly time accounting grouped by activity as a downloadable file payload (bytes).
+
+.. code-block:: python
+
+    from zammad_py import ZammadAPI
+    client = ZammadAPI(url='<HOST>', username='<USERNAME>', password='<PASSWORD>')
+    monthly = client.time_accounting.log_by_activity(2022, 12)
+    csv_bytes = client.time_accounting.log_by_activity_download(2022, 12)
 
 Object Resource
 ---------------

--- a/tests/cassettes/TestAPI.test_ticket_time_accountings.yaml
+++ b/tests/cassettes/TestAPI.test_ticket_time_accountings.yaml
@@ -1,0 +1,31 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - user
+      Connection:
+      - keep-alive
+      User-Agent:
+      - Zammad API Python
+    method: GET
+    uri: http://localhost:8080/api/v1/tickets/1/time_accountings
+  response:
+    body:
+      string: '[{"id":1,"ticket_id":1,"ticket_number":"10001","time_unit":"2.0","created_by_id":3,"created_at":"2022-12-01T08:30:00.000Z"},{"id":2,"ticket_id":1,"ticket_number":"10001","time_unit":"0.5","created_by_id":3,"created_at":"2022-12-02T10:15:00.000Z"}]'
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 13 May 2025 09:11:09 GMT
+      Server:
+      - nginx
+    status:
+      code: 200
+      message: OK
+version: 1
+

--- a/tests/cassettes/TestAPI.test_time_accounting.yaml
+++ b/tests/cassettes/TestAPI.test_time_accounting.yaml
@@ -1,0 +1,112 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - user
+      Connection:
+      - keep-alive
+      User-Agent:
+      - Zammad API Python
+    method: GET
+    uri: http://localhost:8080/api/v1/time_accounting/log/by_activity/2022/12
+  response:
+    body:
+      string: '[{"activity_id":1,"activity_name":"Development","time_unit":"3.0","created_at":"2022-12-05T10:00:00.000Z","ticket_id":1,"ticket_title":"Test
+        Ticket","agent_name":"John Smith"},{"activity_id":2,"activity_name":"Support","time_unit":"1.5","created_at":"2022-12-12T14:30:00.000Z","ticket_id":2,"ticket_title":"Another
+        Ticket","agent_name":"Jane Doe"}]'
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, Depth, User-Agent, X-File-Size, X-Requested-With, If-Modified-Since,
+        X-File-Name, Cache-Control, Accept-Language
+      Access-Control-Allow-Methods:
+      - POST, GET, PUT, DELETE, PATCH, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Max-Age:
+      - '1728000'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 13 May 2025 09:11:09 GMT
+      Server:
+      - nginx
+      Vary:
+      - Accept
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Request-Id:
+      - a1b2c3d4-e5f6-7890-abcd-ef1234567890
+      X-Runtime:
+      - '0.105432'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - user
+      Connection:
+      - keep-alive
+      User-Agent:
+      - Zammad API Python
+    method: GET
+    uri: http://localhost:8080/api/v1/time_accounting/log/by_activity/2022/12?download=true
+  response:
+    body:
+      string: "Activity,Time (hrs),Ticket,Agent,Date\r\nDevelopment,3.0,Test Ticket,John
+        Smith,2022-12-05\r\nSupport,1.5,Another Ticket,Jane Doe,2022-12-12\r\n"
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, Depth, User-Agent, X-File-Size, X-Requested-With, If-Modified-Since,
+        X-File-Name, Cache-Control, Accept-Language
+      Access-Control-Allow-Methods:
+      - POST, GET, PUT, DELETE, PATCH, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Max-Age:
+      - '1728000'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Disposition:
+      - attachment; filename="time_accounting_2022_12.csv"
+      Content-Type:
+      - text/csv; charset=utf-8
+      Date:
+      - Tue, 13 May 2025 09:11:09 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Request-Id:
+      - b2c3d4e5-f6a7-8901-bcde-f12345678901
+      X-Runtime:
+      - '0.098765'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1
+

--- a/tests/test_zammad_py.py
+++ b/tests/test_zammad_py.py
@@ -86,6 +86,16 @@ class TestAPI:
         assert result[0]["title"] == "Welcome to Zammad!"
 
     @pytest.mark.vcr()
+    def test_ticket_time_accountings(self, zammad_api):
+        time_accountings = zammad_api.ticket.time_accountings(1)
+
+        assert isinstance(time_accountings, list)
+        assert len(time_accountings) == 2
+        assert time_accountings[0]["ticket_id"] == 1
+        assert time_accountings[0]["ticket_number"] == "10001"
+        assert time_accountings[0]["time_unit"] == "2.0"
+
+    @pytest.mark.vcr()
     def test_groups(self, zammad_api):
         all_groups = zammad_api.group.all()._items
         assert all_groups[0]["id"] == 1
@@ -348,6 +358,41 @@ class TestAPI:
 
         with pytest.raises(MissingParameterError):
             zammad_api.knowledge_bases_categories.create({"name": "No KB ID"})
+
+    @pytest.mark.vcr()
+    def test_time_accounting(self, zammad_api):
+        # JSON log by activity
+        records = zammad_api.time_accounting.log_by_activity(2022, 12)
+        assert isinstance(records, list)
+        assert len(records) == 2
+        assert records[0]["activity_name"] == "Development"
+        assert records[0]["time_unit"] == "3.0"
+        assert records[1]["activity_name"] == "Support"
+        assert records[1]["time_unit"] == "1.5"
+
+        # CSV download returns bytes (non-JSON response)
+        csv_data = zammad_api.time_accounting.log_by_activity_download(2022, 12)
+        assert isinstance(csv_data, bytes)
+        assert b"Development" in csv_data
+        assert b"Support" in csv_data
+
+        # Standard CRUD methods are disabled for TimeAccounting
+        ta = zammad_api.time_accounting
+        unused_calls = [
+            (ta.all, []),
+            (ta.search, ["query"]),
+            (ta.find, [1]),
+            (ta.create, [{}]),
+            (ta.update, [1, {}]),
+            (ta.destroy, [1]),
+        ]
+
+        for method, args in unused_calls:
+            with pytest.raises(UnusedResourceError) as excinfo:
+                method(*args)
+            assert "is not available for the TimeAccounting resource" in str(
+                excinfo.value
+            )
 
     def test_push_on_behalf_of_header(self, zammad_api):
         zammad_api.on_behalf_of = "USERX"

--- a/zammad_py/api.py
+++ b/zammad_py/api.py
@@ -170,6 +170,11 @@ class ZammadAPI:
         return TicketTag(connection=self)
 
     @property
+    def time_accounting(self) -> "TimeAccounting":
+        """Return a `TimeAccounting` instance"""
+        return TimeAccounting(connection=self)
+
+    @property
     def knowledge_bases(self) -> "KnowledgeBases":
         """Return a `KnowledgeBases` instance"""
         return KnowledgeBases(connection=self)
@@ -411,6 +416,14 @@ class Ticket(Resource):
         )
         return self._raise_or_return_json(response)
 
+    def time_accountings(self, id: int) -> Any:
+        """Returns all time accounting entries associated with the ticket id
+
+        :param id: Ticket id
+        """
+        response = self._connection.session.get(self.url + f"/{id}/time_accountings")
+        return self._raise_or_return_json(response)
+
     def merge(self, id: int, number: int) -> Any:
         """Merges two tickets, (undocumented in Zammad Docs)
         If the objects are already merged, it will return "Object already exists!"
@@ -601,6 +614,57 @@ class TicketTag(Resource):
 
         response = self._connection.session.delete(self.url + "/remove", json=params)
         return self._raise_or_return_json(response)
+
+
+class TimeAccounting(Resource):
+    path_attribute = "time_accounting"
+
+    def log_by_activity(self, year: int, month: int) -> Any:
+        """Returns time accounting records grouped by activity for the given month as JSON
+
+        :param year: The year (e.g. 2022)
+        :param month: The month as a number 1-12 (e.g. 12)
+        """
+        response = self._connection.session.get(
+            self._connection.url + f"time_accounting/log/by_activity/{year}/{month}"
+        )
+        return self._raise_or_return_json(response)
+
+    def log_by_activity_download(self, year: int, month: int) -> Any:
+        """Downloads time accounting records grouped by activity for the given month as a CSV file
+
+        :param year: The year (e.g. 2022)
+        :param month: The month as a number 1-12 (e.g. 12)
+        """
+        response = self._connection.session.get(
+            self._connection.url + f"time_accounting/log/by_activity/{year}/{month}",
+            params={"download": "true"},
+        )
+        return self._raise_or_return_json(response)
+
+    def all(self, page: int = 1, filters=None) -> Pagination:
+        """Disabled: Use log_by_activity() to retrieve time accounting records"""
+        raise UnusedResourceError(self.__class__.__name__, "all")
+
+    def search(self, search_string: str, page: int = 1, filters=None) -> Pagination:
+        """Disabled: Time accounting search is not supported"""
+        raise UnusedResourceError(self.__class__.__name__, "search")
+
+    def find(self, id: int) -> Any:
+        """Disabled: Time accounting find is not supported"""
+        raise UnusedResourceError(self.__class__.__name__, "find")
+
+    def create(self, params: Any) -> Any:
+        """Disabled: Time accounting create is not supported"""
+        raise UnusedResourceError(self.__class__.__name__, "create")
+
+    def update(self, id: int, params: Any) -> Any:
+        """Disabled: Time accounting update is not supported"""
+        raise UnusedResourceError(self.__class__.__name__, "update")
+
+    def destroy(self, id: int) -> Any:
+        """Disabled: Time accounting destroy is not supported"""
+        raise UnusedResourceError(self.__class__.__name__, "destroy")
 
 
 class KnowledgeBases(Resource):


### PR DESCRIPTION
This pull request adds support for the TimeAccounting resource.

Allowing users to retrieve time accounting data grouped by activity, download monthly reports, and access time accounting entries associated with tickets. It also updates documentation and adds tests for the new functionality. Standard CRUD operations are intentionally disabled for the TimeAccounting resource to match API capabilities (they may exist but are undocumented).

**TimeAccounting resource implementation:**

* Added a new `TimeAccounting` class to `zammad_py/api.py` with methods to retrieve monthly time accounting grouped by activity as JSON (`log_by_activity`) and as a downloadable CSV file (`log_by_activity_download`). Standard CRUD methods (`all`, `search`, `find`, `create`, `update`, `destroy`) are explicitly disabled and raise `UnusedResourceError`.
* Added a `time_accounting` property to the API client for convenient access to the new resource.

**Ticket resource enhancements:**

* Added a `time_accountings(id)` method to the `Ticket` resource to fetch all time accounting entries associated with a specific ticket.

**Documentation updates:**

* Updated `README.md` and `docs/usage.rst` to document the new `TimeAccounting` resource, its methods, and the new `ticket.time_accountings(id)` method. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R73) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R86) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R106-R109) [[4]](diffhunk://#diff-c4b284a0e8c330264ebefb4d3d14dd5bb68fe3b72c2ae656f49132e2c134b84fR129) [[5]](diffhunk://#diff-c4b284a0e8c330264ebefb4d3d14dd5bb68fe3b72c2ae656f49132e2c134b84fR169-R178) [[6]](diffhunk://#diff-c4b284a0e8c330264ebefb4d3d14dd5bb68fe3b72c2ae656f49132e2c134b84fR274-R291)

**Testing:**

* Added new tests to `tests/test_zammad_py.py` for `ticket.time_accountings`, `time_accounting.log_by_activity`, `time_accounting.log_by_activity_download`, and for verifying that disabled CRUD methods raise errors. [[1]](diffhunk://#diff-8c0994b32de3e2ed168003fba10eae7a006eb08b43908337495f099247877098R88-R97) [[2]](diffhunk://#diff-8c0994b32de3e2ed168003fba10eae7a006eb08b43908337495f099247877098R362-R396)
* Added VCR cassettes for the new endpoints in `tests/cassettes/TestAPI.test_ticket_time_accountings.yaml` and `tests/cassettes/TestAPI.test_time_accounting.yaml`. [[1]](diffhunk://#diff-f555cf7156dca4a32605e2cf518f339142f93a021c769773960f62464ad9d9a8R1-R31) [[2]](diffhunk://#diff-7a4a433b0262e2aef93c2e6a144062fb50cac13f37a668c005d8185a7378804eR1-R112)